### PR TITLE
fix: tooltip opacity and out of container display

### DIFF
--- a/src/atoms/tooltip/helpers.ts
+++ b/src/atoms/tooltip/helpers.ts
@@ -104,6 +104,13 @@ export const handleTooltipArrowPosition = ({ placement }: WrapperProps) => {
   }
 };
 
+export const displayIfInContainer = ({ outOfContainer }: WrapperProps) => {
+  return !outOfContainer
+    ? `visibility: visible;
+       opacity: 1;`
+    : ``;
+};
+
 export const getTooltipBgColorByType = (type: TooltipType) => {
   switch (type) {
     case 'info':


### PR DESCRIPTION
- Fix tooltip opacity bug when the button is disabled: wrapped the button child with a `div` 
- Fix tooltip being displayed out of container: the placement is correctly calculated and the `Tooltip` component throws when there is no placement possible in the current container but the styled component wrapper TooltipWrapper kept displaying the tooltip based on the user given placement. Fixed this by making styled-component `TooltipWrapper` component aware when there is no possible placement. So now, when there is no possibility to display the tooltip in the container, we simply keep the tooltip hidden and the error will be displayed in the console