### PR TITLE
feat: use unified tabWidth for prettier autoformat

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# top-most EditorConfig file
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,7 @@
   "parserOptions": {
     "project": "./tsconfig.json"
   },
-  "plugins": ["@typescript-eslint", "react", "json", "import"],
+  "plugins": ["@typescript-eslint", "prettier", "react", "json", "import"],
   "extends": [
     "eslint:recommended",
     "plugin:react/recommended",

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,6 +1,4 @@
 module.exports = {
   singleQuote: true,
-  jsxSingleQuote: true,
-  tabWidth: 2,
-  useTabs: false
+  jsxSingleQuote: true
 };

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,4 +1,6 @@
-module.exports =  {
-    singleQuote:  true,
-    jsxSingleQuote: true
+module.exports = {
+  singleQuote: true,
+  jsxSingleQuote: true,
+  tabWidth: 2,
+  useTabs: false
 };

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,11 +103,17 @@ All you need to do is :
 
 ### Code linting and formatting
 
-We use `prettier` to format and `eslint` with typescript settings to lint our code.
+We use `prettier` to format and `eslint` with typescript settings to lint our code. Your IDE should also be able to respect the rules defined with `EditorConfig`.
 
 ### Good to know :
 
-- It's convenient to configure your ide in order automatically format your files. Please follow this [Editor Integration documentation](https://prettier.io/docs/en/editors.html).
+- It's convenient to configure your IDE in order to automatically format your files. Please follow this [Prettier Editor Integration documentation](https://prettier.io/docs/en/editors.html).
+
+- To ensure your IDE is already correctly configured, we use [EditorConfig](https://editorconfig.org/). Please install the required plugin for it, if your IDE needs one:
+
+  - [VSCode plugin](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig)
+  - [Vim plugin](https://github.com/editorconfig/editorconfig-vim)
+  - WebStorm supports it natively.
 
 - Otherwise, we have a yarn task that formats your <strong>git staged files</strong> for you. You can simply run `yarn pretty-quick`
 


### PR DESCRIPTION
We need a unified auto-formatting, especially for tabs/spaces in CSS. Otherwise we'll get undesired line changes in commits. Let's do it before the repository grows too much.