### PR TITLE
feat: fix typo for Dropdown in components index

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,4 @@
 export { default as DropdownMenu } from './dropdown/DropdownMenu';
-export { default as DropDownElement } from './dropdown/DropDownElement';
+export { default as DropdownElement } from './dropdown/DropdownElement';
 export { default as Tooltip } from './tooltip/Tooltip';
 export * from './tooltip/types';


### PR DESCRIPTION
Master was not building because of a casing issue (`DropDown` instead of `Dropdown`). I 