### PR TITLE
feat: remove cursor:pointer from icons

### DIFF
--- a/src/ions/icon/base/Icon.spec.tsx
+++ b/src/ions/icon/base/Icon.spec.tsx
@@ -16,7 +16,7 @@ describe('<Icon>', () => {
         const IconWrapper = mount(<Icon />);
 
         expect(IconWrapper).toHaveStyleRule('fill', 'inherit');
-        expect(IconWrapper).toHaveStyleRule('cursor', 'pointer');
+        expect(IconWrapper).toHaveStyleRule('cursor', 'inherit');
         expect(IconWrapper).toHaveStyleRule('width', '20px');
         expect(IconWrapper).toHaveStyleRule('height', '20px');
       });

--- a/src/ions/icon/base/Icon.tsx
+++ b/src/ions/icon/base/Icon.tsx
@@ -19,7 +19,7 @@ const Icon = styled.svg.attrs<Props>(({ viewBox }: Props) => ({
   display: flex;
   width: ${getWidth};
   height: ${getHeight};
-  cursor: ${({ disabled }): string => (disabled ? 'not-allowed' : 'pointer')};
+  cursor: ${({ disabled }): string => (disabled ? 'not-allowed' : 'inherit')};
   outline: none;
   border-radius: 4px;
   fill: ${getColor()};

--- a/src/ions/icon/base/__snapshots__/Icon.spec.tsx.snap
+++ b/src/ions/icon/base/__snapshots__/Icon.spec.tsx.snap
@@ -8,7 +8,7 @@ exports[`<Icon> global render should render 1`] = `
   display: flex;
   width: 20px;
   height: 20px;
-  cursor: pointer;
+  cursor: inherit;
   outline: none;
   border-radius: 4px;
   fill: inherit;

--- a/src/ions/icon/wrapper/__snapshots__/SvgWrapper.spec.tsx.snap
+++ b/src/ions/icon/wrapper/__snapshots__/SvgWrapper.spec.tsx.snap
@@ -16,7 +16,7 @@ exports[`<SvgIcon> global render should render 1`] = `
           "componentStyle": ComponentStyle {
             "componentId": "sc-bdVaJa",
             "isStatic": false,
-            "lastClassName": "cCEOKG",
+            "lastClassName": "exeUui",
             "rules": Array [
               "
   display: flex;
@@ -66,7 +66,7 @@ exports[`<SvgIcon> global render should render 1`] = `
       forwardedRef={null}
     >
       <svg
-        className="sc-bdVaJa cCEOKG"
+        className="sc-bdVaJa exeUui"
         version="1.1"
         viewBox="0 0 20 20"
         xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
Default icons have no reason to ship with `cursor: pointer`. They should instead inherit the cursor style of their parents.