### PR TITLE
chore(update doc): edit step by step guides titles for better navigation

### DIFF
--- a/documentation/COLOR_STEPBYSTEP.md
+++ b/documentation/COLOR_STEPBYSTEP.md
@@ -1,3 +1,7 @@
+---
+name: Color Step-by-Step
+---
+
 # How to add a color
 
 In order to avoid repetitive/manual work to create color stylesheets, we choose to generate them. Here's a step by step guide to add a color:

--- a/documentation/COMPONENT_STEPBYSTEPGUIDE.md
+++ b/documentation/COMPONENT_STEPBYSTEPGUIDE.md
@@ -1,3 +1,7 @@
+---
+name: Component Step-by-Step
+---
+
 # Create your first component
 
 Are you working on a feature that requires a new component? Do you want to migrate a duplicated component into the component library? Do you want to have fun with Dashlane Design System? You are in the right place! Here you'll find a step by step guide to add a new component. In this example we create a `Button` component

--- a/documentation/FAQ.md
+++ b/documentation/FAQ.md
@@ -1,3 +1,7 @@
+---
+name: FAQ
+---
+
 # Frequently Asked Questions
 
 ### Where do those `docs` files appearing in my PR come from?

--- a/documentation/ICON_STEPBYSTEP.md
+++ b/documentation/ICON_STEPBYSTEP.md
@@ -1,3 +1,7 @@
+---
+name: Icon Step-by-Step
+---
+
 # How to add an icon
 
 In order to avoid repetitive/manual work to create svg icons components (since they are all similar and only the content of the svg changes [see `src/atoms/icons` folder]), we choose to generate them. Here's a step by step guide to add an icon:


### PR DESCRIPTION
Just noticed that the toolbar of the docs were not very readable with the `Component_stepbystep` name, so I added the DocZ header to give a proper name to the documentation.