### PR TITLE
fix(text-input): edit border colors when focused and not to match design

### DIFF
--- a/src/components/text-input/TextInput.module.scss
+++ b/src/components/text-input/TextInput.module.scss
@@ -11,7 +11,7 @@
   flex-direction: column;
   align-items: flex-start;
 
-  &.fluid {
+  &.fullWidth {
     max-width: 100%;
     width: 100%;
   }
@@ -70,7 +70,7 @@
     color: colors.$dash-green-03;
   }
 
-  &.fluid {
+  &.fullWidth {
     max-width: 100%;
     width: 100%;
   }
@@ -81,7 +81,7 @@
   color: colors.$black;
   margin-top: 4px;
 
-  &.fluid {
+  &.fullWidth {
     max-width: 100%;
     width: 100%;
   }

--- a/src/components/text-input/TextInput.module.scss
+++ b/src/components/text-input/TextInput.module.scss
@@ -10,6 +10,11 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
+
+  &.fluid {
+    max-width: 100%;
+    width: 100%;
+  }
 }
 
 .input {
@@ -64,12 +69,22 @@
   &::-ms-input-placeholder {
     color: colors.$dash-green-03;
   }
+
+  &.fluid {
+    max-width: 100%;
+    width: 100%;
+  }
 }
 
 .feedback {
   @include typography.body-small;
   color: colors.$black;
   margin-top: 4px;
+
+  &.fluid {
+    max-width: 100%;
+    width: 100%;
+  }
 }
 
 .feedback.warning {

--- a/src/components/text-input/TextInput.module.scss
+++ b/src/components/text-input/TextInput.module.scss
@@ -28,12 +28,12 @@
   align-items: center;
 
   /* border */
-  border: 1px solid colors.$dash-green-03;
+  border: 1px solid colors.$dash-green-05;
   border-radius: 4px;
   box-sizing: border-box;
 
   &:focus {
-    border-color: colors.$mid-green-00;
+    border-color: colors.$mid-green-01;
   }
 
   &.warning,

--- a/src/components/text-input/TextInput.spec.tsx
+++ b/src/components/text-input/TextInput.spec.tsx
@@ -41,5 +41,16 @@ describe('<TextInput>', () => {
 
       expect(textInput).toMatchSnapshot();
     });
+
+    it('should render with fluid class', () => {
+      const textInput = mount(<TextInput fluid />);
+
+      expect(textInput).toMatchSnapshot();
+      expect(textInput.props().fluid).toBeTruthy();
+      expect(textInput.find('input').getElement().props).toHaveProperty(
+        'className',
+        'input fluid'
+      );
+    });
   });
 });

--- a/src/components/text-input/TextInput.spec.tsx
+++ b/src/components/text-input/TextInput.spec.tsx
@@ -43,13 +43,13 @@ describe('<TextInput>', () => {
     });
 
     it('should render with fluid class', () => {
-      const textInput = mount(<TextInput fluid />);
+      const textInput = mount(<TextInput fullWidth />);
 
       expect(textInput).toMatchSnapshot();
-      expect(textInput.props().fluid).toBeTruthy();
+      expect(textInput.props().fullWidth).toEqual(true);
       expect(textInput.find('input').getElement().props).toHaveProperty(
         'className',
-        'input fluid'
+        'input fullWidth'
       );
     });
   });

--- a/src/components/text-input/TextInput.tsx
+++ b/src/components/text-input/TextInput.tsx
@@ -19,31 +19,37 @@ interface TextInputProps
    * Make this field take 100% of the width of it's container
    * @default false
    */
-  fluid?: boolean;
+  fullWidth?: boolean;
 }
 
 export const TextInput: React.FC<TextInputProps> = ({
   feedbackType,
   feedbackText,
-  fluid = false,
+  fullWidth = false,
   ...htmlInputProps
 }) => {
   const feedbackCssClass =
     feedbackType && styles[feedbackType] ? styles[feedbackType] : '';
 
-  const fluidCssClass = fluid && styles.fluid ? styles.fluid : '';
-
   return (
     <div
-      className={getClassNames(styles.root, feedbackCssClass, fluidCssClass)}
+      className={getClassNames(styles.root, feedbackCssClass, {
+        [styles.fullWidth]: fullWidth
+      })}
     >
       <input
         {...htmlInputProps}
-        className={getClassNames(styles.input, feedbackCssClass, fluidCssClass)}
+        className={getClassNames(styles.input, feedbackCssClass, {
+          [styles.fullWidth]: fullWidth
+        })}
         type='text'
       />
       {feedbackText && feedbackType ? (
-        <span className={getClassNames(styles.feedback, feedbackCssClass)}>
+        <span
+          className={getClassNames(styles.feedback, feedbackCssClass, {
+            [styles.fullWidth]: fullWidth
+          })}
+        >
           {feedbackText}
         </span>
       ) : null}

--- a/src/components/text-input/TextInput.tsx
+++ b/src/components/text-input/TextInput.tsx
@@ -7,23 +7,39 @@ type _ForbiddenProps = 'size' | 'prefix' | 'type';
 
 interface TextInputProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, _ForbiddenProps> {
+  /**
+   * The feedback nature of the input
+   */
   feedbackType?: TextInputFeedbackType;
+  /**
+   * Some text to display under the input when triggering a feedback type
+   */
   feedbackText?: string;
+  /**
+   * Make this field take 100% of the width of it's container
+   * @default false
+   */
+  fluid?: boolean;
 }
 
 export const TextInput: React.FC<TextInputProps> = ({
   feedbackType,
   feedbackText,
+  fluid = false,
   ...htmlInputProps
 }) => {
   const feedbackCssClass =
     feedbackType && styles[feedbackType] ? styles[feedbackType] : '';
 
+  const fluidCssClass = fluid && styles.fluid ? styles.fluid : '';
+
   return (
-    <div className={getClassNames(styles.root, feedbackCssClass)}>
+    <div
+      className={getClassNames(styles.root, feedbackCssClass, fluidCssClass)}
+    >
       <input
         {...htmlInputProps}
-        className={getClassNames(styles.input, feedbackCssClass)}
+        className={getClassNames(styles.input, feedbackCssClass, fluidCssClass)}
         type='text'
       />
       {feedbackText && feedbackType ? (

--- a/src/components/text-input/__snapshots__/TextInput.spec.tsx.snap
+++ b/src/components/text-input/__snapshots__/TextInput.spec.tsx.snap
@@ -95,3 +95,18 @@ exports[`<TextInput> Global render should render warning and show feedback text 
   </div>
 </Component>
 `;
+
+exports[`<TextInput> Global render should render with fluid class 1`] = `
+<Component
+  fluid={true}
+>
+  <div
+    className="root fluid"
+  >
+    <input
+      className="input fluid"
+      type="text"
+    />
+  </div>
+</Component>
+`;

--- a/src/components/text-input/__snapshots__/TextInput.spec.tsx.snap
+++ b/src/components/text-input/__snapshots__/TextInput.spec.tsx.snap
@@ -98,13 +98,13 @@ exports[`<TextInput> Global render should render warning and show feedback text 
 
 exports[`<TextInput> Global render should render with fluid class 1`] = `
 <Component
-  fluid={true}
+  fullWidth={true}
 >
   <div
-    className="root fluid"
+    className="root fullWidth"
   >
     <input
-      className="input fluid"
+      className="input fullWidth"
       type="text"
     />
   </div>


### PR DESCRIPTION
I noticed that the focus border color and the idle border color were not the same than the ones on the Figma file, so quick update to this component.