### PR TITLE
docs(component): fix typo & example code

### DIFF
--- a/documentation/COMPONENT_STEPBYSTEPGUIDE.md
+++ b/documentation/COMPONENT_STEPBYSTEPGUIDE.md
@@ -148,13 +148,13 @@ style={{
 
 Now you [can launch docz](../CONTRIBUTING.md#developing-on-docz) and see your working component in the live documentation 🎉
 
-> 🐞docz has a known bug with props cache and TypeScript, sometimes Props aren't displayed in the documentation. docz tasks (`yarn docoz:dev` and `yarn docz:build`) will clean up docz cache automatically, but if you experience this while docz is runing in watch mode, kill it and relaunch it
+> 🐞docz has a known bug with props cache and TypeScript, sometimes Props aren't displayed in the documentation. docz tasks (`yarn docz:dev` and `yarn docz:build`) will clean up docz cache automatically, but if you experience this while docz is runing in watch mode, kill it and relaunch it
 
 7. Last but not least, let's add some tests. We use [jest](https://jestjs.io/) and [Enzyme](https://enzymejs.github.io/enzyme/) to run snapshot and unit tests. Create a file `Button.spec.tsx`
 
 ```typescript jsx
 import * as React from 'react';
-import { mount } from 'enzyme';
+import { mount, ReactWrapper } from 'enzyme';
 import 'jest-styled-components';
 import { Button, ButtonProps } from './Button';
 
@@ -173,7 +173,7 @@ describe('<Button>', () => {
     it('should render default', () => {
       wrapper = createWrapper({});
       expect(wrapper).toMatchSnapshot();
-      expect(wrapper.exists('.root.medium')).toEqual(true);
+      expect(wrapper.exists('.medium')).toEqual(true);
     });
 
     it('should render small', () => {
@@ -181,7 +181,7 @@ describe('<Button>', () => {
         size: 'small'
       });
       expect(wrapper).toMatchSnapshot();
-      expect(wrapper.exists('.root.small')).toEqual(true);
+      expect(wrapper.exists('.small')).toEqual(true);
     });
 
     it('should render large', () => {
@@ -189,7 +189,7 @@ describe('<Button>', () => {
         size: 'large'
       });
       expect(wrapper).toMatchSnapshot();
-      expect(wrapper.exists('.root.large')).toEqual(true);
+      expect(wrapper.exists('.large')).toEqual(true);
     });
   });
 });


### PR DESCRIPTION
Fix a few minor issues in the component creation step-by-step guide.

- typo:
  "docoz" -> "docz"

- example:
  Test code was missing an import variable and was expecting a
  non-existent "root" class