### PR TITLE
refactor(password-strength): unify indicators into a single progress

### DIFF
--- a/src/components/password-strength/PasswordStrength.module.scss
+++ b/src/components/password-strength/PasswordStrength.module.scss
@@ -6,7 +6,7 @@
   flex-direction: column;
   align-items: flex-start;
   margin-top: 8px;
-  max-width: 317px;
+  max-width: 318px;
 
   &.fullWidth {
     max-width: 100%;
@@ -24,24 +24,30 @@
       max-width: 100%;
     }
 
-    .passwordStrength {
+    .passwordStrengthBackground {
+      width: 100%;
       background-color: colors.$dash-green-05;
-      border-radius: 12px;
+      border-radius: 2px;
       height: 4px;
-      margin: 0px 4px;
-      width: 20%;
+      position: relative;
 
-      &:first-child {
-        margin-left: 0px;
+      > span {
+        display: block;
+        height: 100%;
       }
+    }
 
-      &:last-child {
-        margin-right: 0px;
-      }
+    .passwordStrength {
+      display: block;
+      border-radius: 2px;
+      height: 100%;
+      transition: width 1s ease-out;
+      -moz-transition: width 1s ease-out;
+      -webkit-transition: width 1s ease-out;
 
       &.weakest,
       &.weak {
-        background-color: colors.$red-00;
+        background-color: colors.$accessible-validator-red;
       }
 
       &.acceptable {
@@ -50,7 +56,7 @@
 
       &.good,
       &.strong {
-        background-color: colors.$validator-green;
+        background-color: colors.$accessible-validator-green;
       }
     }
   }

--- a/src/components/password-strength/PasswordStrength.tsx
+++ b/src/components/password-strength/PasswordStrength.tsx
@@ -40,6 +40,7 @@ export const PasswordStrength = ({
   showAdditionalText
 }: PasswordStrengthProps) => {
   const strengthClassName = classNameColorScoreMapping[score];
+  const strengthLevel = (score * 100) / 4;
 
   return (
     <div
@@ -50,36 +51,17 @@ export const PasswordStrength = ({
           [styles.fullWidth]: fullWidth
         })}
       >
-        <span
-          className={getClassNames(
-            styles.passwordStrength,
-            score >= 0 ? strengthClassName : ''
-          )}
-        ></span>
-        <span
-          className={getClassNames(
-            styles.passwordStrength,
-            score >= 1 ? strengthClassName : ''
-          )}
-        ></span>
-        <span
-          className={getClassNames(
-            styles.passwordStrength,
-            score >= 2 ? strengthClassName : ''
-          )}
-        ></span>
-        <span
-          className={getClassNames(
-            styles.passwordStrength,
-            score >= 3 ? strengthClassName : ''
-          )}
-        ></span>
-        <span
-          className={getClassNames(
-            styles.passwordStrength,
-            score >= 4 ? strengthClassName : ''
-          )}
-        ></span>
+        <div className={getClassNames(styles.passwordStrengthBackground)}>
+          <span
+            style={{
+              width: `${strengthLevel}%`
+            }}
+            className={getClassNames(
+              styles.passwordStrength,
+              strengthClassName
+            )}
+          ></span>
+        </div>
       </div>
       {showAdditionalText && additionalText && (
         <span className={styles.additionalInfo}>{additionalText}</span>


### PR DESCRIPTION
This is how it will look associated with a Password Input :
![image](https://user-images.githubusercontent.com/22549509/80599998-12fd3680-8a2c-11ea-925c-78195a238409.png)

And here are the variations :
![image](https://user-images.githubusercontent.com/22549509/80600982-750a6b80-8a2d-11ea-884c-f08d66ad2fac.png)

And this is the behaviour when the value changes : 
![CleanShot 2020-04-29 at 16 04 20](https://user-images.githubusercontent.com/22549509/80605330-3d9ebd80-8a33-11ea-879d-407e046f3ea7.gif)

