### PR TITLE
style(iconz): fix mdx

### DIFF
--- a/src/atoms/icons/Icons.mdx
+++ b/src/atoms/icons/Icons.mdx
@@ -68,6 +68,7 @@ import { WebIcon } from './WebIcon';
 import { WindowsIcon } from './WindowsIcon';
 
 import { IconsWrapper } from '@utility/icons-wrapper/IconsWrapper';
+
 # Icons
 
 UI-components offers a set of icons ready to be used in a web application.


### PR DESCRIPTION
For some reason the `yarn docz:dev` command doesn't work anymore since I've rebased on master: the parser needed that space.

Couldn't find what caused the issue though :thinking: 
![snapshot515](https://user-images.githubusercontent.com/2964863/81192508-9da8dd00-8fba-11ea-8e32-eeed0b57df47.png)
