### PR TITLE
fix(icon-button): fix background and border colors

### DIFF
--- a/src/components/icon-button/IconButton.module.scss
+++ b/src/components/icon-button/IconButton.module.scss
@@ -5,6 +5,8 @@
   min-width: unset;
   min-height: unset;
 
+  /* Size */
+
   &.small {
     height: 32px;
     width: 32px;
@@ -21,5 +23,32 @@
     height: 48px;
     width: 48px;
     padding: 12px;
+  }
+
+  /* Colors based on Theme */
+
+  &.light {
+    &:focus,
+    &:hover:enabled {
+      border-color: colors.$dash-green-05;
+    }
+
+    &:active:enabled {
+      border-color: colors.$dash-green-05;
+      background-color: colors.$dash-green-05;
+    }
+  }
+
+  &.dark {
+    &:focus,
+    &:hover:enabled {
+      background-color: colors.$dash-green-01;
+      border-color: colors.$dash-green-01;
+    }
+
+    &:active:enabled {
+      background-color: colors.$dash-green-02;
+      border-color: colors.$dash-green-02;
+    }
   }
 }

--- a/src/components/icon-button/IconButton.tsx
+++ b/src/components/icon-button/IconButton.tsx
@@ -23,7 +23,7 @@ export const IconButton: React.FC<IconButtonProps> = ({
       size={size}
       theme={theme}
       {...htmlButtonProps}
-      className={getClassNames(styles.iconButton, styles[size])}
+      className={getClassNames(styles.iconButton, styles[size], styles[theme])}
     >
       {icon}
     </Button>

--- a/src/components/icon-button/__snapshots__/IconButton.spec.tsx.snap
+++ b/src/components/icon-button/__snapshots__/IconButton.spec.tsx.snap
@@ -32,13 +32,13 @@ exports[`<IconButton> Global render should render default 1`] = `
   icon={<Unknown />}
 >
   <Component
-    className="iconButton small"
+    className="iconButton small light"
     nature="ghost"
     size="small"
     theme="light"
   >
     <button
-      className="button ghost small light iconButton small"
+      className="button ghost small light iconButton small light"
     >
       <span
         className="content"
@@ -186,13 +186,13 @@ exports[`<IconButton> Style properties should render large size 1`] = `
   size="large"
 >
   <Component
-    className="iconButton large"
+    className="iconButton large light"
     nature="ghost"
     size="large"
     theme="light"
   >
     <button
-      className="button ghost large light iconButton large"
+      className="button ghost large light iconButton large light"
     >
       <span
         className="content"
@@ -340,13 +340,13 @@ exports[`<IconButton> Style properties should render medium size 1`] = `
   size="medium"
 >
   <Component
-    className="iconButton medium"
+    className="iconButton medium light"
     nature="ghost"
     size="medium"
     theme="light"
   >
     <button
-      className="button ghost medium light iconButton medium"
+      className="button ghost medium light iconButton medium light"
     >
       <span
         className="content"
@@ -494,13 +494,13 @@ exports[`<IconButton> Style properties should render small size 1`] = `
   size="small"
 >
   <Component
-    className="iconButton small"
+    className="iconButton small light"
     nature="ghost"
     size="small"
     theme="light"
   >
     <button
-      className="button ghost small light iconButton small"
+      className="button ghost small light iconButton small light"
     >
       <span
         className="content"


### PR DESCRIPTION
Fixes the icon buttons' background color and border color to respect the figma designs. 