### PR TITLE
fix(types): fix type declaration import alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,9 @@
     "sass-loader": "^8.0.2",
     "semantic-release": "^15.13.27",
     "ts-jest": "^24.0.2",
-    "typescript": "^3.7.3"
+    "ttypescript": "^1.5.10",
+    "typescript": "^3.7.3",
+    "typescript-transform-paths": "^1.1.14"
   },
   "resolutions": {
     "webpack": "4.30.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,4 @@
+import ttypescript from 'ttypescript';
 import postcss from 'rollup-plugin-postcss';
 import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import typescript from 'rollup-plugin-typescript2';
@@ -19,7 +20,7 @@ const config = {
       plugins: [autoprefixer()]
     }),
     typescript({
-      typescript: require('typescript'),
+      typescript: ttypescript,
       objectHashIgnoreUnknownHack: true
     }),
     json({ preferConst: true })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,13 @@
       "@typings/*": ["typings/*"],
       "@utility/*": ["utility/*"],
       "@design-tokens/*": ["design-tokens/*"]
-    }
+    },
+    "plugins": [
+      {
+        "transform": "typescript-transform-paths",
+        "afterDeclarations": true
+      }
+    ]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "src/**/*.spec.ts"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -15944,6 +15944,13 @@ resolve@^1.11.1, resolve@^1.15.1:
   dependencies:
     path-parse "^1.0.6"
 
+resolve@^1.9.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
+  integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
+  dependencies:
+    path-parse "^1.0.6"
+
 responselike@1.0.2, responselike@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/responselike/-/responselike-1.0.2.tgz#918720ef3b631c5642be068f15ade5a46f4ba1e7"
@@ -17953,6 +17960,13 @@ tty-browserify@0.0.0:
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
   integrity sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=
 
+ttypescript@^1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/ttypescript/-/ttypescript-1.5.10.tgz#5045083a91cf09a735ecc95d4711c1f3b83f2059"
+  integrity sha512-Hk7TRej1hM+p+Fo+Pyb/XK9pe9CAt3Sh5n5YRutxFS8hUgkh2u1Vd2K40kMcNP3WYhiVFBMqXwM/2E8O95Ep6g==
+  dependencies:
+    resolve "^1.9.0"
+
 tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
@@ -18021,6 +18035,13 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typescript-transform-paths@^1.1.14:
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/typescript-transform-paths/-/typescript-transform-paths-1.1.14.tgz#4a3800a04977a527270980488f9c93055a31e474"
+  integrity sha512-oUXMH4D+GSqr/tGMlQVOB0RC9IUj1NokQVzRSbD+YeER5gR/U7vqj8KKrwuRSGd1xgKP/St+HjM8zoB57wVGDA==
+  dependencies:
+    slash "^3.0.0"
 
 typescript@3.5.3, typescript@>=3.8.3, typescript@^3.7.3:
   version "3.8.3"


### PR DESCRIPTION
Fixes an issue in the ts declaration files. 

Basically the rollup configuration we have does not resolve the import alias of typescript declaration files. In other words if a dev imports only a type from a file like:

```ts
import { Placement } from '@components/Tooltip/types'
```

In the build files, we would have a .d.ts file with the same import:

 ```ts
import { Placement } from '@components/Tooltip/types'
```

This led to the ui components types to be completely broken.

This PR addresses this issue by resolving the imports.