### PR TITLE
build(docz): prevent exec-docz-update silent failure

### DIFF
--- a/config/updateDoczBuild.js
+++ b/config/updateDoczBuild.js
@@ -27,7 +27,9 @@ exec('git show HEAD --name-only', (err, stdout) => {
 
   console.log('Building the documentation...');
   exec('yarn docz:build', error => {
-    if (!error) {
+    if (error) {
+      throw error;
+    } else {
       console.log('Committing the new changes');
       commitChange();
     }


### PR DESCRIPTION
Prevent `yarn exec-docz-update` (usually executed as a post commit hook) from hiding potential failures.

One error I encountered and that was silently ignored was: `System limit for number of file watchers reached`, this PR doesn't fix it but will at least show it and return a non-zero exit status.