### PR TITLE
Chore/export otp field

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -8,6 +8,7 @@ export { BusinessLogo } from './business-logo/BusinessLogo';
 export { Button } from './button/Button';
 export { Card } from './card/Card';
 export { Checkbox } from './checkbox/Checkbox';
+export { OTPField } from './otp-field/OTPField';
 export { DLogo } from './d-logo/DLogo';
 export { DropdownElement } from './dropdown/DropdownElement';
 export { DropdownMenu } from './dropdown/DropdownMenu';

--- a/src/components/otp-field/OTPField.module.scss
+++ b/src/components/otp-field/OTPField.module.scss
@@ -26,7 +26,6 @@
     position: relative;
     display: flex;
     align-items: center;
-    margin-bottom: 4px;
     max-width: 100%;
     width: 100%;
 

--- a/src/components/otp-field/OTPField.tsx
+++ b/src/components/otp-field/OTPField.tsx
@@ -43,7 +43,11 @@ export const OTPField = ({
       <span className={styles.label}>{label}</span>
       <div className={styles.container}>
         <div className={styles.code}>{formattedCode}</div>
-        <TimerClock onTimerEnd={resetCode} {...clockProps} />
+        <TimerClock
+          key={clockProps.validityEndDate}
+          onTimerEnd={resetCode}
+          {...clockProps}
+        />
       </div>
     </div>
   );

--- a/src/components/otp-field/TimerClock.module.scss
+++ b/src/components/otp-field/TimerClock.module.scss
@@ -1,7 +1,7 @@
 @use '../../colors/colors';
 @use '../../typography/typography';
 
-.base-timer {
+.baseTimer {
   position: relative;
   height: 14px;
   width: 14px;
@@ -10,17 +10,17 @@
   padding: 2px;
 }
 
-.base-timer-circle {
+.baseTimerCircle {
   fill: none;
   stroke: none;
 }
 
-.base-timer-path-elapsed {
+.baseTimerPathElapsed {
   stroke-width: 2px;
   stroke: colors.$dash-green-04;
 }
 
-.base-timer-path-remaining {
+.baseTimerPathRemaining {
   stroke-width: 2px;
   transform: rotate(90deg);
   transform-origin: center;
@@ -28,11 +28,11 @@
   transition: stroke-dasharray 1s linear;
   stroke: colors.$mid-green-00;
 
-  &.alert-path {
+  &.alertPath {
     stroke: colors.$orange-00;
   }
 }
 
-.base-timer-svg {
+.baseTimerSvg {
   transform: scaleX(-1);
 }

--- a/src/components/otp-field/TimerClock.tsx
+++ b/src/components/otp-field/TimerClock.tsx
@@ -38,16 +38,15 @@ export const TimerClock = ({
   const [timeLeft, setTimeLeft] = React.useState(validityPeriod);
 
   React.useEffect(() => {
+    // Set the timeLeft to the real time left to catch up the possible delay
+    setTimeLeft(validityEndDate - Date.now());
+  }, [validityEndDate, onTimerEnd]);
+
+  React.useEffect(() => {
     if (timeRef.current && timeLeft < 0) {
       timeRef.current && clearTimeout(timeRef.current);
       onTimerEnd && onTimerEnd();
       return;
-    }
-
-    // Set the timeLeft to the real time left to catch up the possible delay
-    // Important to have a 'catch up' animation
-    if (!timeRef.current) {
-      setTimeLeft(validityEndDate - Date.now());
     }
 
     // Update the timeLeft each second (in sync with the 1s animation of the SVG)

--- a/src/components/otp-field/__snapshots__/OTPField.spec.tsx.snap
+++ b/src/components/otp-field/__snapshots__/OTPField.spec.tsx.snap
@@ -24,23 +24,30 @@ exports[`<OTPField> Global render should render default 1`] = `
         000 000
       </div>
       <Component
+        key="1592829231510"
         onTimerEnd={[Function]}
         validityEndDate={1592829231510}
         validityPeriod={30000}
       >
-        <div>
+        <div
+          className="baseTimer"
+        >
           <svg
+            className="baseTimerSvg"
             viewBox="0 0 14 14"
             xmlns="http://www.w3.org/2000/svg"
           >
-            <g>
+            <g
+              className="baseTimerCircle"
+            >
               <circle
+                className="baseTimerPathElapsed"
                 cx="7"
                 cy="7"
                 r="6"
               />
               <path
-                className=""
+                className="baseTimerPathRemaining"
                 d="
               M 7, 7
               m -6, 0


### PR DESCRIPTION
I made a mistake and I forgot to export the OTPField in my last PR. This fixes the issue.

I also fixed the SCSS. For some reason, the documentation accepts kebab case class names but when the project is built and used in the Popup, the css class names do not appear. Having Pascal SCSS class names fixes this issue.

I also removed the animation regarding the catch up when the otp clock has a delay. 