### PR TITLE
refactor: remove value from slider label

### DIFF
--- a/src/components/slider/Slider.spec.tsx
+++ b/src/components/slider/Slider.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 import { Slider } from './Slider';
 
@@ -7,35 +7,30 @@ describe('<Slider />', () => {
   it('should render default', () => {
     const label = 'Slider';
     const value = 50;
-    const { asFragment, queryByText } = render(
-      <Slider value={value} label={label} />
-    );
+    const { asFragment } = render(<Slider value={value} label={label} />);
 
     expect(asFragment()).toMatchSnapshot();
-    expect(queryByText(`${label} (${value})`)).not.toBe(null);
-    expect(queryByText('0')).toBeInTheDocument();
-    expect(queryByText('100')).toBeInTheDocument();
+
+    expect(screen.queryByText(label)).toBeInTheDocument();
+    expect(screen.queryByText('0')).toBeInTheDocument();
+    expect(screen.queryByText('100')).toBeInTheDocument();
   });
 
   it('should render with a tooltip on press', () => {
     const value = 30;
     const label = 'Slider';
-    const { getByLabelText, queryByText } = render(
-      <Slider value={value} label={label} />
-    );
-    const slider = getByLabelText(`${label} (${value})`);
+    render(<Slider value={value} label={label} />);
+    const slider = screen.getByLabelText(label);
     fireEvent.mouseDown(slider);
-    expect(queryByText(value.toString())).toBeInTheDocument();
+    expect(screen.queryByText(value.toString())).toBeInTheDocument();
   });
 
   it('should not render with a tooltip on press when tooltip is set to false', () => {
     const value = 30;
     const label = 'Slider';
-    const { getByLabelText, queryByText } = render(
-      <Slider value={value} label={label} tooltip={false} />
-    );
-    const slider = getByLabelText(`${label} (${value})`);
+    render(<Slider value={value} label={label} tooltip={false} />);
+    const slider = screen.getByLabelText(label);
     fireEvent.mouseDown(slider);
-    expect(queryByText(value.toString())).not.toBeInTheDocument();
+    expect(screen.queryByText(value.toString())).not.toBeInTheDocument();
   });
 });

--- a/src/components/slider/Slider.tsx
+++ b/src/components/slider/Slider.tsx
@@ -18,6 +18,7 @@ export interface SliderProps {
   step?: number;
   tooltip?: boolean;
   className?: string;
+  id?: string;
 }
 
 export const Slider = ({
@@ -28,6 +29,7 @@ export const Slider = ({
   max = 100,
   step = 1,
   tooltip = true,
+  id = 'slider',
   onChange,
   onChangeComplete,
   ...otherProps
@@ -101,12 +103,12 @@ export const Slider = ({
 
   return (
     <div className={getClassNames(styles.sliderContainer, className)}>
-      <label htmlFor={`slider-${label}`} className={styles.sliderLabel}>
-        {label} ({value})
+      <label htmlFor={id} className={styles.sliderLabel}>
+        {label}
       </label>
       <input
         {...otherProps}
-        id={`slider-${label}`}
+        id={id}
         type='range'
         ref={sliderRef}
         min={min}
@@ -117,11 +119,7 @@ export const Slider = ({
         onChange={handleOnChange}
       />
       {tooltip ? (
-        <output
-          className={styles.tooltip}
-          ref={tooltipRef}
-          htmlFor={`slider-${label}`}
-        >
+        <output className={styles.tooltip} ref={tooltipRef} htmlFor={id}>
           <span className={styles.tooltipContent}>{value}</span>
         </output>
       ) : null}

--- a/src/components/slider/__snapshots__/Slider.spec.tsx.snap
+++ b/src/components/slider/__snapshots__/Slider.spec.tsx.snap
@@ -7,13 +7,13 @@ exports[`<Slider /> should render default 1`] = `
   >
     <label
       class="sliderLabel"
-      for="slider-Slider"
+      for="slider"
     >
-      Slider (50)
+      Slider
     </label>
     <input
       class="sliderRange"
-      id="slider-Slider"
+      id="slider"
       max="100"
       min="0"
       step="1"
@@ -22,7 +22,7 @@ exports[`<Slider /> should render default 1`] = `
     />
     <output
       class="tooltip"
-      for="slider-Slider"
+      for="slider"
     >
       <span
         class="tooltipContent"


### PR DESCRIPTION
Slight change to slider component, removing the actualized value from the label - can still be provided by the parent component. 
