### PR TITLE
refactor: updating infobox typing for children

### DIFF
--- a/src/components/info-box/InfoBox.module.scss
+++ b/src/components/info-box/InfoBox.module.scss
@@ -61,7 +61,7 @@
 
 .description {
   @include typography.body-small;
-  padding: 0 16px;
+  padding: 0 16px 16px 16px;
   margin-top: 0px;
 }
 

--- a/src/components/info-box/InfoBox.tsx
+++ b/src/components/info-box/InfoBox.tsx
@@ -14,10 +14,10 @@ export interface InfoBoxProps {
   title: string;
   size?: InfoBoxSize;
   severity?: InfoBoxSeverity;
-  children?: string;
-  primary?: Function;
+  children?: React.ReactNode;
+  primary?: (event?: React.SyntheticEvent<HTMLElement>) => void;
   primaryLabel?: string;
-  secondary?: Function;
+  secondary?: (event?: React.SyntheticEvent<HTMLElement>) => void;
   secondaryLabel?: string;
 }
 
@@ -36,7 +36,7 @@ const showActions = ({
           size='small'
           theme={severity === 'strong' ? 'dark' : 'light'}
           className={styles.actionsBtn}
-          onClick={() => secondary()}
+          onClick={secondary}
         >
           {secondaryLabel}
         </Button>
@@ -48,7 +48,7 @@ const showActions = ({
           size='small'
           theme={severity === 'strong' ? 'dark' : 'light'}
           className={styles.actionsBtn}
-          onClick={() => primary()}
+          onClick={primary}
         >
           {primaryLabel}
         </Button>
@@ -90,7 +90,7 @@ export const InfoBox = ({
         <p className={getClassNames(styles.title, styles[size])}>{title}</p>
       </div>
       {size === 'descriptive' ? (
-        <p className={styles.description}> {children} </p>
+        <div className={styles.description}> {children} </div>
       ) : null}
       {showActions({
         severity,


### PR DESCRIPTION
I based myself too much on the "action" of UI-component so children were set to a string instead of a `React.ReactNode` so this is the fix to make it more flexible. It does not change the interface.
No mdx file was changed so no compiled docz file need to be included.