### PR TITLE
fix(password-input): set reveal password button type to "button"

### DIFF
--- a/src/components/password-input/PasswordInput.tsx
+++ b/src/components/password-input/PasswordInput.tsx
@@ -82,6 +82,7 @@ export const PasswordInput = (props: PasswordInputProps): JSX.Element => {
         <button
           className={getClassNames(styles.icon)}
           onClick={handleShowPassword}
+          type='button'
         >
           {prop.disabled ? (
             <RevealOrHideIcon disabled={prop.disabled} />

--- a/src/components/password-input/__snapshots__/PasswordInput.spec.tsx.snap
+++ b/src/components/password-input/__snapshots__/PasswordInput.spec.tsx.snap
@@ -24,6 +24,7 @@ exports[`<PasswordInput /> should render default 1`] = `
       <button
         className="icon"
         onClick={[Function]}
+        type="button"
       >
         <Tooltip
           placement="left"
@@ -218,6 +219,7 @@ exports[`<PasswordInput /> should render error state with feedback text 1`] = `
       <button
         className="icon"
         onClick={[Function]}
+        type="button"
       >
         <Tooltip
           placement="left"
@@ -416,6 +418,7 @@ exports[`<PasswordInput /> should render error state without feedback text 1`] =
       <button
         className="icon"
         onClick={[Function]}
+        type="button"
       >
         <Tooltip
           placement="left"
@@ -610,6 +613,7 @@ exports[`<PasswordInput /> should render warning state with feedback text 1`] = 
       <button
         className="icon"
         onClick={[Function]}
+        type="button"
       >
         <Tooltip
           placement="left"
@@ -808,6 +812,7 @@ exports[`<PasswordInput /> should render warning state without feedback text 1`]
       <button
         className="icon"
         onClick={[Function]}
+        type="button"
       >
         <Tooltip
           placement="left"


### PR DESCRIPTION
I encountered an issue in a consumer of UI-Components where using a Password Input component inside a form and clicking on the reveal / hide button triggers a submit of the form as the default button type is `submit`. This prevents this behaviour by setting the type to button. I tested with this fix, and it solves this form issue